### PR TITLE
Implemented detach clone function - Issue 15

### DIFF
--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -276,7 +276,17 @@ int cbt_get_length(cranbtree_t * cbt)
   */
 void cbt_detach_clone(cranbtree_t * cbt, void *(*copy_object) (void *))
 {
+	/* if there is no tree do nothing */
+	if (cbt == NULL)
+	{
+		return;
+	}
 
+	/* this tree is no longer a clone, mark it as such */
+	cbt->is_clone = false;
+
+	/* copy the objects starting from the root node recursively */
+	cbt_copy_objects(cbt->root, cbt->n, copy_object);
 }
 
 /**

--- a/src/lib/clone.c
+++ b/src/lib/clone.c
@@ -86,3 +86,45 @@ static cbt_node_t *cbt_copy_nodes(cbt_node_t * node, int n)
 	new_node->len = node->len;
 	return new_node;
 }
+
+/** 
+  * cbt_node_t*, int, void* (* copy_object)(void*)) -> void 
+  * EFFECTS: replaces each object pointer in the tree with the result of
+  *          the copy transformation provided by third parameter.
+  * RETURNS: nothing
+  * PARAMETERS:
+  * - cbt_node_t* node: root of the cranbtree to be processed
+  * - int n: the order of the tree
+  * - void* (* copy_object)(void*): the function to be called on each
+  *                                 object
+  *
+  */
+static void cbt_copy_objects(cbt_node_t * node, int n,
+			     void *(*copy_object) (void *))
+{
+	/* if no copy_object is supplied, we're done */
+	if (copy_object == NULL)
+	{
+		return;
+	}
+
+	/* copy every object associated with each entry that exists at this node */
+	for (int i = 0; i < n; i++)
+	{
+		/* if this entry exists, copy its object */
+		if (node->entry[i] != NULL)
+		{
+			node->entry[i]->object =
+			    copy_object(node->entry[i]->object);
+		}
+	}
+
+	/* descend into this node's children if they are defined */
+	for (int i = 0; i < n + 1; i++)
+	{
+		if (node->children[i] != NULL)
+		{
+			cbt_copy_objects(node->children[i], n, copy_object);
+		}
+	}
+}

--- a/src/lib/lib.h
+++ b/src/lib/lib.h
@@ -90,3 +90,5 @@ static void *cbt_update_helper(cbt_node_t * node, int key, void *new_object,
 			       int n);
 static void cbt_copy_metadata(cranbtree_t * src, cranbtree_t * dest);
 static cbt_node_t *cbt_copy_nodes(cbt_node_t * node, int n);
+static void cbt_copy_objects(cbt_node_t * node, int n,
+			     void *(*copy_object) (void *));

--- a/test/comprehensive.c
+++ b/test/comprehensive.c
@@ -146,7 +146,11 @@ void pickNRandomNumber(int arr[], int n)
 
 	for (int i = 0; i < n; i++)
 	{
-		printf("\r\tPicked: %d random numbers ", i + 1);
+		/** Removed output here to make visible 
+		  * Test: cbt_detach_clone_test2 ...passed
+		  * Test: cbt_detach_clone_test3 ...passed
+		  */
+		/*printf("\r\tPicked: %d random numbers ", i + 1);*/
 		r = rand() % n;
 		int swap = arr[r];
 

--- a/test/comprehensive.c
+++ b/test/comprehensive.c
@@ -150,7 +150,7 @@ void pickNRandomNumber(int arr[], int n)
 		  * Test: cbt_detach_clone_test2 ...passed
 		  * Test: cbt_detach_clone_test3 ...passed
 		  */
-		/*printf("\r\tPicked: %d random numbers ", i + 1);*/
+		/*printf("\r\tPicked: %d random numbers ", i + 1); */
 		r = rand() % n;
 		int swap = arr[r];
 

--- a/test/testsuite.c
+++ b/test/testsuite.c
@@ -1742,7 +1742,8 @@ void cbt_detach_clone_test2(void)
 	for (int i = 0; i < n; i++)
 	{
 		void *obj_original = cbt_search(bt, keys[i]);
-		void *obj_clone = cbt_search(bt, keys[i]);
+		void *obj_clone = cbt_search(clone, keys[i]);
+
 		CU_ASSERT_EQUAL(obj_original, obj_clone);
 	}
 	cbt_destroy(bt, free);
@@ -1772,7 +1773,7 @@ void cbt_detach_clone_test3(void)
 	for (int i = 0; i < n; i++)
 	{
 		void *obj_original = cbt_search(bt, keys[i]);
-		void *obj_clone = cbt_search(bt, keys[i]);
+		void *obj_clone = cbt_search(clone, keys[i]);
 
 		CU_ASSERT_NOT_EQUAL(obj_original, obj_clone);
 		int *x = (int *)obj_original;


### PR DESCRIPTION
## Purpose
As described in [issue 15](https://github.com/abdullahemad12/Cranberry-Btree/issues/15), it would be nice to have the ability to make a deep copy of the B tree from a clone. 

## Approach
To perform this, it is necessary to walk the entire tree and create a copy of each object. The old object pointers that were pointed at the original tree will now be pointing to independent copies.

#### Open Questions and Pre-Merge TODOs
All were addressed in [issue thread](https://github.com/abdullahemad12/Cranberry-Btree/issues/15).

## Learning
Aside from a solid understanding of a B tree itself, the first step was to unravel how the data structure is implemented. This is pivotal to understanding the semantics of the algorithm and the function implementation. The next step was to understand how the library is intended to be used.

After reacquainting myself with function pointers, I implemented a recursive traversal of the B tree. Once that was finished I needed to learn how to use the CUnit framework. Since this project was well designed, this was straightforward to do intuitively. Afterwards, I discovered [Notes and samples for CUnit test framework for C](http://wpollock.com/CPlus/CUnitNotes.htm) by [Wayne Pollock](mailto:pollock@acm.org) which is very helpful.

## Issue Number
[Issue 15](https://github.com/abdullahemad12/Cranberry-Btree/issues/15)

#### Blog Posts
[Notes and samples for CUnit test framework for C](http://wpollock.com/CPlus/CUnitNotes.htm) by [Wayne Pollock](mailto:pollock@acm.org)