### PR TITLE
Issue16 ptm

### DIFF
--- a/include/cranbtree.h
+++ b/include/cranbtree.h
@@ -69,9 +69,22 @@ typedef struct cranbtree
 	int min_key;
 	unsigned int n;
 	bool is_clone;
+	int op_errno;
 } cranbtree_t;
 
 /*interface*/
+
+/*
+ * error numbers
+ */
+#define CBT_NO_ERROR        0
+#define CBT_CLONE_BAD_OP    (CBT_NO_ERROR + 1)
+
+/*
+ * cranbtree_t* -> const char* 
+ * Return pointer to string describing last error. NULL if no error recorded.
+ */
+const char* cbt_error(cranbtree_t* bt);
 
 /*
  * int -> bptree_t* 

--- a/include/cranbtree.h
+++ b/include/cranbtree.h
@@ -81,10 +81,16 @@ typedef struct cranbtree
 #define CBT_CLONE_BAD_OP    (CBT_NO_ERROR + 1)
 
 /*
+ * cranbtree_t* -> int
+ * Return pointer to string describing last error. NULL if no error recorded.
+ */
+int cbt_errno(cranbtree_t * bt);
+
+/*
  * cranbtree_t* -> const char* 
  * Return pointer to string describing last error. NULL if no error recorded.
  */
-const char *cbt_error(cranbtree_t * bt);
+const char *cbt_errstr(cranbtree_t * bt);
 
 /*
  * int -> bptree_t* 
@@ -104,15 +110,17 @@ cranbtree_t *cbt_clone(cranbtree_t * cbt);
 
 /**
   * cranbtree_t*, int, void* -> void
-  * EFFECTS: inserts an object in the btree in respect with the search key
+  * EFFECTS: Inserts an object in the btree in respect with the search key.
+  *          Unless the tree is a clone, in which case it return immediately.
+  *          Sets op_errno on any error.
   * MODIFIES: cranbtree_t* bt
-  * RETURNS: void
+  * RETURNS: Pointer to the inserted object or NULL on any error
   *
   * cranbtree_t* bt: Tree structs that will hold the object
   * int key: search key (choosen by the user)
   * void* object: pointer to the object to be inserted
   */
-void cbt_insert(cranbtree_t * bt, int key, void *object);
+void *cbt_insert(cranbtree_t * bt, int key, void *object);
 
 /**
   * cranbtree_t*, int, void* -> void

--- a/include/cranbtree.h
+++ b/include/cranbtree.h
@@ -84,7 +84,7 @@ typedef struct cranbtree
  * cranbtree_t* -> const char* 
  * Return pointer to string describing last error. NULL if no error recorded.
  */
-const char* cbt_error(cranbtree_t* bt);
+const char *cbt_error(cranbtree_t * bt);
 
 /*
  * int -> bptree_t* 

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -47,6 +47,27 @@
 static void destroy_bt_helper(cbt_node_t * root, int n, void (*done) (void *));
 
 /*
+ * errors
+ */
+
+static char *errorMessages[] = {
+	NULL,
+	"Cannot perfrom this operation on a cloned tree",
+};
+
+
+/*
+ * cranbtree_t* -> const char*
+ * Return pointer to string describing last error. NULL if no error recorded.
+ */
+const char* cbt_error(cranbtree_t* bt)
+{
+	assert(bt != NULL);
+
+	return errorMessages[bt->op_errno];
+}
+
+/*
  * int -> bptree_t* 
  * Given the maximum number of entries in a node
  * returns a pointer to an empty B-tree
@@ -77,6 +98,8 @@ cranbtree_t *cbt_create(int n)
 	bt->max_key = -1;
 	bt->n = n;
 	bt->is_clone = false;
+	bt->op_errno = CBT_NO_ERROR;
+
 	return bt;
 }
 
@@ -110,7 +133,9 @@ cranbtree_t *cbt_clone(cranbtree_t * cbt)
 
 /**
   * cranbtree_t*, int, void* -> void
-  * EFFECTS: inserts an object in the btree in respect with the search key
+  * EFFECTS: Inserts an object in the btree in respect with the search key.
+  * 		 Unless the tree is a clone, in which case it return immediately.
+  * 		 Sets op_errno on any error.
   * MODIFIES: cranbtree_t* bt
   * RETURNS: void
   *
@@ -122,6 +147,12 @@ void cbt_insert(cranbtree_t * bt, int key, void *object)
 {
 	assert(bt != NULL);
 	assert(object != NULL);
+	
+	if (bt->is_clone)
+	{
+		bt->op_errno = CBT_CLONE_BAD_OP;
+		return;
+	}
 
 	cbt_entry_t *entry = bt_create_entry(key, object);
 
@@ -147,8 +178,9 @@ void cbt_insert(cranbtree_t * bt, int key, void *object)
   * cranbtree_t*, int, void* -> void
   * MODIFIES: cranbtree_t* 
   * EFFECTS: Updates the object of the entry that has the specified key with the new pointer. If 
-  * 		 no such entry was found a new entry is inserted.
-  * RETURNS: pointer to the old object, NULL if it was not found
+  * 		 no such entry was found a new entry is inserted. Returns immediately if the tree is
+  * 		 a clone. Sets op_errno on any error.
+  * RETURNS: Pointer to the old object, NULL if it was not found.
   * PARAMETERS: 
   * - cranbtree_t* cbt, pointer to the BTree struct
   * - int key: the key of the entry to be updated
@@ -156,6 +188,14 @@ void cbt_insert(cranbtree_t * bt, int key, void *object)
   */
 void *cbt_update(cranbtree_t * bt, int key, void *object)
 {
+	assert(bt != NULL);
+
+	if (bt->is_clone)
+	{
+		bt->op_errno = CBT_CLONE_BAD_OP;
+		return (void *)NULL;
+	}
+
 	void *old_object = cbt_update_helper(bt->root, key, object, bt->n);
 
 	if (old_object == NULL)
@@ -207,13 +247,20 @@ void *cbt_search(cranbtree_t * bt, int key)
 
 /**
   * cranbtree_t*, int -> void*
-  * EFFECTS: Given a key, removes an object from the tree
+  * EFFECTS: Given a key, removes an object from the tree. Sets errno on any error.
   * MODIFIES: cranbtree_t*
-  * RETURNS: returns the object or NULL if no such a key was found
+  * RETURNS: returns the object or NULL if no such a key was found.
   */
 void *cbt_delete(cranbtree_t * bt, int key)
 {
 	assert(bt != NULL);
+
+	if (bt->is_clone)
+	{
+		bt->op_errno = CBT_CLONE_BAD_OP;
+		return (void *)NULL;
+	}
+
 	void *object = bt_delete_helper(bt, bt->root, key);
 
 	if (object != NULL)
@@ -337,3 +384,4 @@ static void destroy_bt_helper(cbt_node_t * root, int n, void (*done) (void *))
 	}
 	bt_destroy_node(root, n, done);
 }
+

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -56,10 +56,21 @@ static char *errorMessages[] = {
 };
 
 /*
+ * cranbtree_t* -> int
+ * Return last detected error code/number
+ */
+int cbt_errno(cranbtree_t * bt)
+{
+	assert(bt != NULL);
+
+	return bt->op_errno;
+}
+
+/*
  * cranbtree_t* -> const char*
  * Return pointer to string describing last error. NULL if no error recorded.
  */
-const char *cbt_error(cranbtree_t * bt)
+const char *cbt_errstr(cranbtree_t * bt)
 {
 	assert(bt != NULL);
 
@@ -136,13 +147,13 @@ cranbtree_t *cbt_clone(cranbtree_t * cbt)
   * 		 Unless the tree is a clone, in which case it return immediately.
   * 		 Sets op_errno on any error.
   * MODIFIES: cranbtree_t* bt
-  * RETURNS: void
+  * RETURNS: Pointer to the inserted object or NULL on any error
   *
   * cranbtree_t* bt: Tree structs that will hold the object
   * int key: search key (choosen by the user)
   * void* object: pointer to the object to be inserted
   */
-void cbt_insert(cranbtree_t * bt, int key, void *object)
+void *cbt_insert(cranbtree_t * bt, int key, void *object)
 {
 	assert(bt != NULL);
 	assert(object != NULL);
@@ -150,7 +161,7 @@ void cbt_insert(cranbtree_t * bt, int key, void *object)
 	if (bt->is_clone)
 	{
 		bt->op_errno = CBT_CLONE_BAD_OP;
-		return;
+		return (cranbtree_t *) NULL;
 	}
 
 	cbt_entry_t *entry = bt_create_entry(key, object);
@@ -171,6 +182,8 @@ void cbt_insert(cranbtree_t * bt, int key, void *object)
 		bt->min_key = bt->min_key > key ? key : bt->min_key;
 	}
 	bt->length++;
+
+	return object;
 }
 
 /**

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -52,7 +52,7 @@ static void destroy_bt_helper(cbt_node_t * root, int n, void (*done) (void *));
 
 static char *errorMessages[] = {
 	NULL,
-	"Cannot perfrom this operation on a cloned tree",
+	"Cannot perform this operation on a cloned tree",
 };
 
 /*

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -55,12 +55,11 @@ static char *errorMessages[] = {
 	"Cannot perfrom this operation on a cloned tree",
 };
 
-
 /*
  * cranbtree_t* -> const char*
  * Return pointer to string describing last error. NULL if no error recorded.
  */
-const char* cbt_error(cranbtree_t* bt)
+const char *cbt_error(cranbtree_t * bt)
 {
 	assert(bt != NULL);
 
@@ -147,7 +146,7 @@ void cbt_insert(cranbtree_t * bt, int key, void *object)
 {
 	assert(bt != NULL);
 	assert(object != NULL);
-	
+
 	if (bt->is_clone)
 	{
 		bt->op_errno = CBT_CLONE_BAD_OP;
@@ -384,4 +383,3 @@ static void destroy_bt_helper(cbt_node_t * root, int n, void (*done) (void *))
 	}
 	bt_destroy_node(root, n, done);
 }
-

--- a/test/testsuite.c
+++ b/test/testsuite.c
@@ -42,7 +42,9 @@ void comp_test(void)
 	{
 		int *z = malloc(sizeof(int));
 
-		cbt_insert(bt, keys[i], z);
+		void *insertedObj = cbt_insert(bt, keys[i], z);
+
+		CU_ASSERT_PTR_NOT_NULL(insertedObj);
 		CU_ASSERT_PTR_NOT_NULL(cbt_search(bt, keys[i]));
 	}
 
@@ -1634,8 +1636,10 @@ void cbt_clone_test5(void)
 	int n = 50;
 
 	/*test no initial error recorded */
-	const char *errorMessage = cbt_error(bt);
+	int errorNo = cbt_errno(bt);
+	const char *errorMessage = cbt_errstr(bt);
 
+	CU_ASSERT(errorNo == 0);
 	CU_ASSERT_PTR_NULL(errorMessage);
 
 	pickNRandomNumber(keys, n);
@@ -1726,7 +1730,9 @@ void cbt_clone_test5(void)
 	CU_ASSERT(treecmp(bt->root, clone->root, bt->n));
 
 	/*last operation of clone failed (was ignored), test error message */
-	errorMessage = cbt_error(clone);
+	errorNo = cbt_errno(clone);
+	errorMessage = cbt_errstr(clone);
+	CU_ASSERT(errorNo == CBT_CLONE_BAD_OP);
 	CU_ASSERT_STRING_EQUAL(errorMessage,
 			       "Cannot perform this operation on a cloned tree");
 

--- a/test/testsuite.c
+++ b/test/testsuite.c
@@ -1634,7 +1634,8 @@ void cbt_clone_test5(void)
 	int n = 50;
 
 	/*test no initial error recorded */
-	const char* errorMessage = cbt_error(bt);
+	const char *errorMessage = cbt_error(bt);
+
 	CU_ASSERT_PTR_NULL(errorMessage);
 
 	pickNRandomNumber(keys, n);
@@ -1678,10 +1679,12 @@ void cbt_clone_test5(void)
 		void *oldobj = cbt_search(clone, keys[i]);
 
 		void *object = cbt_update(clone, keys[i], z);
+
 		CU_ASSERT_PTR_NULL(object);
 		CU_ASSERT_EQUAL(clone->op_errno, CBT_CLONE_BAD_OP);
 
 		void *newobj = cbt_search(clone, keys[i]);
+
 		CU_ASSERT_EQUAL(oldobj, newobj);
 		CU_ASSERT_NOT_EQUAL(z, newobj);
 	}
@@ -1695,7 +1698,7 @@ void cbt_clone_test5(void)
 		CU_ASSERT_EQUAL(clone->op_errno, CBT_CLONE_BAD_OP);
 	}
 
-	/*makes sure nothing was inserted*/
+	/*makes sure nothing was inserted */
 
 	CU_ASSERT_EQUAL(clone->length, bt->length);
 	CU_ASSERT_EQUAL(clone->n, bt->n);
@@ -1709,11 +1712,12 @@ void cbt_clone_test5(void)
 	{
 		clone->op_errno = CBT_NO_ERROR;
 		void *object = cbt_delete(clone, keys[i]);
+
 		CU_ASSERT_PTR_NULL(object);
 		CU_ASSERT_EQUAL(clone->op_errno, CBT_CLONE_BAD_OP);
 	}
 
-	/*makes sure nothing was deleted*/
+	/*makes sure nothing was deleted */
 
 	CU_ASSERT_EQUAL(clone->length, bt->length);
 	CU_ASSERT_EQUAL(clone->n, bt->n);
@@ -1721,9 +1725,10 @@ void cbt_clone_test5(void)
 	CU_ASSERT_EQUAL(clone->min_key, bt->min_key);
 	CU_ASSERT(treecmp(bt->root, clone->root, bt->n));
 
-	/*last operation of clone failed (was ignored), test error message*/
+	/*last operation of clone failed (was ignored), test error message */
 	errorMessage = cbt_error(clone);
-	CU_ASSERT_STRING_EQUAL(errorMessage, "Cannot perfrom this operation on a cloned tree");
+	CU_ASSERT_STRING_EQUAL(errorMessage,
+			       "Cannot perfrom this operation on a cloned tree");
 
 	cbt_destroy(clone, free);
 	cbt_destroy(bt, free);

--- a/test/testsuite.c
+++ b/test/testsuite.c
@@ -1728,7 +1728,7 @@ void cbt_clone_test5(void)
 	/*last operation of clone failed (was ignored), test error message */
 	errorMessage = cbt_error(clone);
 	CU_ASSERT_STRING_EQUAL(errorMessage,
-			       "Cannot perfrom this operation on a cloned tree");
+			       "Cannot perform this operation on a cloned tree");
 
 	cbt_destroy(clone, free);
 	cbt_destroy(bt, free);


### PR DESCRIPTION
# Purpose
The insert, update and delete should do nothing when called on a clone tree.

# Approach

1. Added 'bt->is_clone' test to the appropriate functions to ignore the request and return null, having first set an error number on tree structure.
2. Implemented bt->error() function to return error message.
3. Updated 'cbt_clone_test5' to match change of functionality.

# Issue Number
#16 