### PR TITLE
Added error code for key not found

### DIFF
--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -259,8 +259,11 @@ void *cbt_search(cranbtree_t * bt, int key)
   */
 void *cbt_delete(cranbtree_t * bt, int key)
 {
-	assert(bt != NULL);
-
+	//assert(bt != NULL);
+	if (bt == NULL)
+	{
+		bt->op_errno = CBT_KEY_NOT_FOUND;
+	}
 	if (bt->is_clone)
 	{
 		bt->op_errno = CBT_CLONE_BAD_OP;

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -199,11 +199,10 @@ void *cbt_update(cranbtree_t * bt, int key, void *object)
 		return (void *)NULL;
 	}
 
-	if(object == NULL)
-	{
-		bt->op_errno = CBT_KEY_NOT_FOUND;
+	if(cbt_update_if_exists(bt, key, object) == NULL){
 		return (void *)NULL;
 	}
+
 
 	void *old_object = cbt_update_helper(bt->root, key, object, bt->n);
 
@@ -228,7 +227,7 @@ void *cbt_update(cranbtree_t * bt, int key, void *object)
 void *cbt_update_if_exists(cranbtree_t * bt, int key, void *object)
 {
 	if(object==NULL){
-		bt->op_errno == CBT_KEY_NOT_FOUND;
+		bt->op_errno = CBT_KEY_NOT_FOUND;
 		return NULL;
 	}
 	else{

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -147,11 +147,8 @@ cranbtree_t *cbt_clone(cranbtree_t * cbt)
 void *cbt_insert(cranbtree_t * bt, int key, void *object)
 {
 	assert(bt != NULL);
-	//assert(object != NULL);
-	if(object == NULL) {
-		bt->op_errno = CBT_KEY_NOT_FOUND;
-	}
-
+	assert(object != NULL);
+	
 	if (bt->is_clone)
 	{
 		bt->op_errno = CBT_CLONE_BAD_OP;
@@ -259,11 +256,8 @@ void *cbt_search(cranbtree_t * bt, int key)
   */
 void *cbt_delete(cranbtree_t * bt, int key)
 {
-	//assert(bt != NULL);
-	if (bt == NULL)
-	{
-		bt->op_errno = CBT_KEY_NOT_FOUND;
-	}
+	assert(bt != NULL);
+	
 	if (bt->is_clone)
 	{
 		bt->op_errno = CBT_CLONE_BAD_OP;

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -199,11 +199,16 @@ void *cbt_update(cranbtree_t * bt, int key, void *object)
 		return (void *)NULL;
 	}
 
+	if(object == NULL)
+	{
+		bt->op_errno = CBT_KEY_NOT_FOUND;
+		return (void *)NULL;
+	}
+
 	void *old_object = cbt_update_helper(bt->root, key, object, bt->n);
 
 	if (old_object == NULL)
 	{
-		bt->op_errno = CBT_KEY_NOT_FOUND;
 		cbt_insert(bt, key, object);
 	}
 	return old_object;
@@ -222,7 +227,13 @@ void *cbt_update(cranbtree_t * bt, int key, void *object)
   */
 void *cbt_update_if_exists(cranbtree_t * bt, int key, void *object)
 {
-	return NULL;
+	if(object==NULL){
+		bt->op_errno == CBT_KEY_NOT_FOUND;
+		return NULL;
+	}
+	else{
+		return object;
+	}
 }
 
 /**
@@ -233,7 +244,11 @@ void *cbt_update_if_exists(cranbtree_t * bt, int key, void *object)
   *
   */
 int cbt_key_search(cranbtree_t * cbt, void *object)
-{
+{	
+	if(object == NULL){
+		cbt->op_errno = CBT_KEY_NOT_FOUND;
+		return -1;
+	}
 	return 0;
 }
 
@@ -246,11 +261,14 @@ int cbt_key_search(cranbtree_t * cbt, void *object)
 void *cbt_search(cranbtree_t * bt, int key)
 {
 	assert(bt != NULL);
-	if(bt_search_helper(bt->root, key, bt->n) == NULL)
-	{
-		bt->op_errno = CBT_KEY_NOT_FOUND;
+	void *object = bt_search_helper(bt->root, key, bt->n);
+	
+	if(cbt_key_search(bt, object)== -1){
+		return (void *)NULL;
 	}
-	return bt_search_helper(bt->root, key, bt->n);
+	else{
+	return object;
+	}
 }
 
 /**
@@ -285,6 +303,7 @@ void *cbt_delete(cranbtree_t * bt, int key)
 	else
 	{
 		bt->op_errno = CBT_KEY_NOT_FOUND;
+		return (void *)NULL;
 	}
 
 	return object;

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -247,7 +247,7 @@ void *cbt_search(cranbtree_t * bt, int key)
 	assert(bt != NULL);
 	void *object = bt_search_helper(bt->root, key, bt->n);
 	
-	if(cbt_key_search(bt, object)== (-1)){
+	if(object==NULL){
 		return (void *)NULL;
 	}
 	else{

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -233,13 +233,7 @@ void *cbt_update_if_exists(cranbtree_t * bt, int key, void *object)
   */
 int cbt_key_search(cranbtree_t * cbt, void *object)
 {	
-	if(object == NULL){
-		cbt->op_errno = CBT_KEY_NOT_FOUND;
-		return -1;
-	}
-	else{
-	return 0;
-	}
+	
 }
 
 /**

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -245,6 +245,10 @@ int cbt_key_search(cranbtree_t * cbt, void *object)
 void *cbt_search(cranbtree_t * bt, int key)
 {
 	assert(bt != NULL);
+	if(bt_search_helper(bt->root, key, bt->n) == NULL)
+	{
+		bt->op_errno = CBT_KEY_NOT_FOUND;
+	}
 	return bt_search_helper(bt->root, key, bt->n);
 }
 

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -277,6 +277,11 @@ void *cbt_delete(cranbtree_t * bt, int key)
 		bt->length--;
 	}
 
+	else
+	{
+		bt->op_errno = CBT_KEY_NOT_FOUND;
+	}
+
 	return object;
 }
 

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -221,13 +221,7 @@ void *cbt_update(cranbtree_t * bt, int key, void *object)
   */
 void *cbt_update_if_exists(cranbtree_t * bt, int key, void *object)
 {
-	if(object==NULL){
-		bt->op_errno = CBT_KEY_NOT_FOUND;
-		return NULL;
-	}
-	else{
-		return object;
-	}
+	
 }
 
 /**

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -42,6 +42,12 @@
 #include "lib/clone.c"
 
 /*
+ *macros
+ */
+
+#define CBT_KEY_NOT_FOUND 2
+
+/*
  * prototypes
  */
 static void destroy_bt_helper(cbt_node_t * root, int n, void (*done) (void *));
@@ -205,6 +211,7 @@ void *cbt_update(cranbtree_t * bt, int key, void *object)
 	if (old_object == NULL)
 	{
 		cbt_insert(bt, key, object);
+		return CBT_KEY_NOT_FOUND;
 	}
 	return old_object;
 }
@@ -380,7 +387,7 @@ static void destroy_bt_helper(cbt_node_t * root, int n, void (*done) (void *))
 {
 	if (root == NULL)
 	{
-		return;
+		return CBT_KEY_NOT_FOUND;
 	}
 	for (int i = 0, n1 = n + 1; i < n1; i++)
 	{

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -221,7 +221,7 @@ void *cbt_update(cranbtree_t * bt, int key, void *object)
   */
 void *cbt_update_if_exists(cranbtree_t * bt, int key, void *object)
 {
-	
+	return;
 }
 
 /**
@@ -233,7 +233,7 @@ void *cbt_update_if_exists(cranbtree_t * bt, int key, void *object)
   */
 int cbt_key_search(cranbtree_t * cbt, void *object)
 {	
-	
+	return 0;
 }
 
 /**

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -201,10 +201,6 @@ void *cbt_update(cranbtree_t * bt, int key, void *object)
 
 	void *old_object = cbt_update_helper(bt->root, key, object, bt->n);
 
-	if(cbt_update_if_exists(bt, key, old_object) == NULL){
-		return (void *)NULL;
-	}
-
 	if (old_object == NULL)
 	{
 		cbt_insert(bt, key, object);

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -199,12 +199,11 @@ void *cbt_update(cranbtree_t * bt, int key, void *object)
 		return (void *)NULL;
 	}
 
-	if(cbt_update_if_exists(bt, key, object) == NULL){
+	void *old_object = cbt_update_helper(bt->root, key, object, bt->n);
+
+	if(cbt_update_if_exists(bt, key, old_object) == NULL){
 		return (void *)NULL;
 	}
-
-
-	void *old_object = cbt_update_helper(bt->root, key, object, bt->n);
 
 	if (old_object == NULL)
 	{

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -203,6 +203,7 @@ void *cbt_update(cranbtree_t * bt, int key, void *object)
 
 	if (old_object == NULL)
 	{
+		bt->op_errno = CBT_KEY_NOT_FOUND;
 		cbt_insert(bt, key, object);
 	}
 	return old_object;

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -248,7 +248,9 @@ int cbt_key_search(cranbtree_t * cbt, void *object)
 		cbt->op_errno = CBT_KEY_NOT_FOUND;
 		return -1;
 	}
+	else{
 	return 0;
+	}
 }
 
 /**
@@ -262,7 +264,7 @@ void *cbt_search(cranbtree_t * bt, int key)
 	assert(bt != NULL);
 	void *object = bt_search_helper(bt->root, key, bt->n);
 	
-	if(cbt_key_search(bt, object)== -1){
+	if(cbt_key_search(bt, object)== (-1)){
 		return (void *)NULL;
 	}
 	else{

--- a/src/cranbtree.c
+++ b/src/cranbtree.c
@@ -42,12 +42,6 @@
 #include "lib/clone.c"
 
 /*
- *macros
- */
-
-#define CBT_KEY_NOT_FOUND 2
-
-/*
  * prototypes
  */
 static void destroy_bt_helper(cbt_node_t * root, int n, void (*done) (void *));
@@ -153,7 +147,10 @@ cranbtree_t *cbt_clone(cranbtree_t * cbt)
 void *cbt_insert(cranbtree_t * bt, int key, void *object)
 {
 	assert(bt != NULL);
-	assert(object != NULL);
+	//assert(object != NULL);
+	if(object == NULL) {
+		bt->op_errno = CBT_KEY_NOT_FOUND;
+	}
 
 	if (bt->is_clone)
 	{
@@ -210,7 +207,6 @@ void *cbt_update(cranbtree_t * bt, int key, void *object)
 	if (old_object == NULL)
 	{
 		cbt_insert(bt, key, object);
-		return CBT_KEY_NOT_FOUND;
 	}
 	return old_object;
 }
@@ -386,7 +382,7 @@ static void destroy_bt_helper(cbt_node_t * root, int n, void (*done) (void *))
 {
 	if (root == NULL)
 	{
-		return CBT_KEY_NOT_FOUND;
+		return;
 	}
 	for (int i = 0, n1 = n + 1; i < n1; i++)
 	{

--- a/src/lib/search.c
+++ b/src/lib/search.c
@@ -32,6 +32,7 @@ static void *bt_search_helper(cbt_node_t * node, int key, int n)
 {
 	if (node == NULL)
 	{
+		bt->op_errorno = CBT_KEY_NOT_FOUND;
 		return NULL;
 	}
 

--- a/src/lib/search.c
+++ b/src/lib/search.c
@@ -32,7 +32,6 @@ static void *bt_search_helper(cbt_node_t * node, int key, int n)
 {
 	if (node == NULL)
 	{
-		bt->op_errorno = CBT_KEY_NOT_FOUND;
 		return NULL;
 	}
 


### PR DESCRIPTION

## Pull Request Template: 


## Purpose
_We need to have a error code for helpers(for search, delete and update) returning as NULL._

## Approach
_I created a macro ```#define CBT_KEY_NOT_FOUND 2``` and returned it every time helper was NULL. _

#### Open Questions and Pre-Merge TODOs
- [x] Did I miss anyplace to return the error code? 

## Issue Number
This pull request if for Issue #19 
